### PR TITLE
change Cable locked sensor to BinarySensorDeviceClass.LOCK

### DIFF
--- a/custom_components/keba/binary_sensor.py
+++ b/custom_components/keba/binary_sensor.py
@@ -51,7 +51,7 @@ SENSOR_TYPES = [
     BinarySensorEntityDescription(
         key="Plug_locked",
         name="Cable locked",
-        device_class=BinarySensorDeviceClass.PLUG,
+        device_class=BinarySensorDeviceClass.LOCK,
         entity_registry_enabled_default=False,
     ),
     BinarySensorEntityDescription(


### PR DESCRIPTION
This changes the `cable_locked` sensor to BinarySensorDeviceClass.LOCK, which is more appropriate and fixes #15 