### PR TITLE
Add config flow tests

### DIFF
--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,1 @@
+"""Helps enable tests for custom component."""

--- a/custom_components/keba/const.py
+++ b/custom_components/keba/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Abfallplus integration."""
+"""Constants for the Keba integration."""
 
 DOMAIN = "keba"
 CHARGING_STATIONS = "wallboxes"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Fixtures for Keba integration tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.keba.const import DOMAIN
+
+from homeassistant.const import CONF_HOST
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+import pytest
+
+P30_TITLE = "P30"
+P30_ID = "12345678"
+P30_IP = "192.168.1.11"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):  # pylint: disable=unused-argument
+    """Automatically enables custom integrations for tests."""
+    yield
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        title=P30_TITLE,
+        domain=DOMAIN,
+        data={
+            CONF_HOST: P30_IP,
+        },
+        unique_id=P30_ID,
+        entry_id="test_entry_id",
+    )
+
+
+@pytest.fixture
+def mock_keba() -> Generator[AsyncMock]:
+    """Return a mock Keba instance."""
+    with (
+        patch(
+            "custom_components.keba.config_flow.get_keba_connection", autospec=True
+        ) as mocked_keba,
+        patch("custom_components.keba.get_keba_connection", new=mocked_keba),
+    ):
+        keba = mocked_keba.return_value
+
+        device_info = MagicMock()
+        device_info.model = "P30"
+        device_info.device_id = P30_ID
+        keba.get_device_info.return_value = device_info
+
+        yield keba

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,57 @@
+"""Test the Keba config flow."""
+
+from unittest.mock import AsyncMock
+
+from custom_components.keba.config_flow import CannotConnect
+from custom_components.keba.const import DOMAIN
+import pytest
+
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import P30_IP, P30_TITLE
+
+
+@pytest.mark.usefixtures("mock_keba", "mock_config_entry")
+async def test_config_flow(
+    hass: HomeAssistant,
+) -> None:
+    """Test the Keba config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    # Simulate user input
+    user_input = {CONF_HOST: P30_IP}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == P30_TITLE
+    assert result["data"][CONF_HOST] == P30_IP
+
+
+async def test_config_flow_errors(hass: HomeAssistant, mock_keba: AsyncMock) -> None:
+    """Test error handling in the Keba config flow."""
+    # Simulate a connection error
+    mock_keba.get_device_info.side_effect = CannotConnect("Connection error")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    user_input = {CONF_HOST: P30_IP}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}


### PR DESCRIPTION
This adds initial tests for the config flow.

For now just with a single discovered charging station, since I need more info on how multiple stations look in the data.