### PR TITLE
Add Support for KEBA P40/P40 Pro Charging Stations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .vscode
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .vscode
 .idea
+.DS_Store

--- a/custom_components/keba/button.py
+++ b/custom_components/keba/button.py
@@ -1,5 +1,6 @@
 """Support for KEBA button entities."""
 
+import logging
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any
@@ -9,12 +10,40 @@ from keba_kecontact.connection import KebaKeContact
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, KEBA_CONNECTION
+from .const import (
+    CHARGING_STATIONS,
+    CONF_DEVICE_TYPE,
+    DEVICE_TYPE_P40,
+    DEVICE_TYPE_UDP,
+    DOMAIN,
+    KEBA_CONNECTION,
+)
 from .entity import KebaBaseEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _is_socket_version(model: str) -> bool:
+    """Check if the P40 model is a socket/plug version (S0) vs cable version (C6).
+
+    Model code pattern: KC-P40-[Leistung][Region]-[Anschluss][Phasen][Zähler]-...
+    - C6 = Cable attached (no socket unlock)
+    - S0 = Socket/plug version (has socket unlock feature)
+    """
+    if not model:
+        return False
+    # Look for S0 in the connection type position (after the power/region code)
+    # Example: KC-P40-16EU0-S0S1AM00-... (socket version)
+    # Example: KC-P40-16EU0-C6S3AE00-... (cable version)
+    parts = model.split("-")
+    if len(parts) >= 4:
+        connection_part = parts[3]  # e.g., "S0S1AM00" or "C6S3AE00"
+        return connection_part.startswith("S0")
+    return False
 
 
 @dataclass(frozen=True)
@@ -24,11 +53,13 @@ class KebaButtonEntityDescription(ButtonEntityDescription):
     remote_function: Callable[[ChargingStation], Coroutine[Any, Any, Any]] | None = None
 
 
+# Common button types for all devices
 BUTTON_TYPES: tuple[KebaButtonEntityDescription, ...] = (
     KebaButtonEntityDescription(
         key="request_data",
         icon="mdi:refresh",
         name="Request data",
+        entity_category=EntityCategory.DIAGNOSTIC,
         remote_function=lambda charging_station: charging_station.request_data(),
     ),
     KebaButtonEntityDescription(
@@ -43,12 +74,25 @@ BUTTON_TYPES: tuple[KebaButtonEntityDescription, ...] = (
         name="Disable",
         remote_function=lambda charging_station: charging_station.disable(),
     ),
+)
+
+# P40 button types - only request_data (Enable/Disable handled by Lock entity)
+P40_BUTTON_TYPES: tuple[KebaButtonEntityDescription, ...] = (
     KebaButtonEntityDescription(
-        key="unlock_socket",
-        icon="mdi:ev-plug-type2",
-        name="Unlock Socket",
-        remote_function=lambda charging_station: charging_station.unlock_socket(),
+        key="request_data",
+        icon="mdi:refresh",
+        name="Request data",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        remote_function=lambda charging_station: charging_station.request_data(),
     ),
+)
+
+# Socket unlock button - only for socket versions
+UNLOCK_SOCKET_BUTTON = KebaButtonEntityDescription(
+    key="unlock_socket",
+    icon="mdi:ev-plug-type2",
+    name="Unlock Socket",
+    remote_function=lambda charging_station: charging_station.unlock_socket(),
 )
 
 
@@ -58,12 +102,28 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the keba charging station buttons from config entry."""
-    keba: KebaKeContact = hass.data[DOMAIN][KEBA_CONNECTION]
-    entities: list[KebaButton] = []
+    device_type = config_entry.data.get(CONF_DEVICE_TYPE, DEVICE_TYPE_UDP)
 
-    charging_station = keba.get_charging_station(config_entry.data[CONF_HOST])
+    if device_type == DEVICE_TYPE_P40:
+        charging_station = hass.data[DOMAIN][CHARGING_STATIONS][config_entry.entry_id]
+        # For P40: use P40_BUTTON_TYPES (no Enable/Disable - handled by Lock entity)
+        # Add unlock_socket only for socket versions (S0)
+        button_types = list(P40_BUTTON_TYPES)
+        model = charging_station.get_value("Model") or ""
+        if _is_socket_version(model):
+            _LOGGER.debug("P40 model %s is a socket version, adding unlock button", model)
+            button_types.append(UNLOCK_SOCKET_BUTTON)
+        else:
+            _LOGGER.debug("P40 model %s is a cable version, skipping unlock button", model)
+    else:
+        keba: KebaKeContact = hass.data[DOMAIN][KEBA_CONNECTION]
+        charging_station = keba.get_charging_station(config_entry.data[CONF_HOST])
+        # For UDP: use all buttons including unlock_socket
+        button_types = list(BUTTON_TYPES) + [UNLOCK_SOCKET_BUTTON]
+
+    entities: list[KebaButton] = []
     entities.extend(
-        [KebaButton(charging_station, description) for description in BUTTON_TYPES]
+        [KebaButton(charging_station, description) for description in button_types]
     )
     async_add_entities(entities, True)
 

--- a/custom_components/keba/config_flow.py
+++ b/custom_components/keba/config_flow.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from ipaddress import ip_network
 import logging
 from typing import Any
 
+import aiohttp
 from keba_kecontact.connection import SetupError
 import voluptuous as vol
 
@@ -18,34 +20,130 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlow,
 )
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
 from . import get_keba_connection
 from .const import CONF_RFID, CONF_RFID_CLASS, DOMAIN
+from .p40_api import P40ApiClient
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_DEVICE_TYPE = "device_type"
+DEVICE_TYPE_UDP = "udp"
+DEVICE_TYPE_P40 = "p40"
 
 STEP_HOST_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_HOST): str,
+        vol.Optional(CONF_PASSWORD): str,
     }
 )
+
+
+async def detect_device_type(host: str) -> str:
+    """Detect if the device is P40 (REST API) or older (UDP)."""
+    _LOGGER.debug("Attempting to detect device type for host: %s", host)
+
+    # Try to connect to P40 REST API endpoint
+    # Note: /serialnumber returns plain text, not JSON
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with asyncio.timeout(3):
+                _LOGGER.debug("Trying P40 REST API endpoint: https://%s:8443/serialnumber", host)
+                async with session.get(
+                    f"https://{host}:8443/serialnumber",
+                    ssl=False,
+                ) as response:
+                    _LOGGER.debug("P40 API response status: %s", response.status)
+                    if response.status == 200:
+                        # Successfully connected to P40 API
+                        serial = await response.text()
+                        _LOGGER.info("Detected P40 device at %s (serial: %s)", host, serial.strip())
+                        return DEVICE_TYPE_P40
+                    elif response.status == 401:
+                        # Auth required, but API exists
+                        _LOGGER.info("Detected P40 device at %s (auth required)", host)
+                        return DEVICE_TYPE_P40
+                    else:
+                        _LOGGER.debug("Unexpected status %s, assuming UDP device", response.status)
+    except asyncio.TimeoutError as err:
+        _LOGGER.debug("P40 detection timeout for %s: %s", host, err)
+    except aiohttp.ClientError as err:
+        _LOGGER.debug("P40 detection client error for %s: %s", host, err)
+    except Exception as err:
+        _LOGGER.debug("P40 detection failed for %s: %s (type: %s)", host, err, type(err).__name__)
+
+    # Default to UDP-based device
+    _LOGGER.info("Defaulting to UDP device type for %s", host)
+    return DEVICE_TYPE_UDP
 
 
 async def validate_input(
     hass: core.HomeAssistant, data: dict[str, Any]
 ) -> dict[str, str]:
     """Validate given keba charging station host by setting it up."""
-    keba = await get_keba_connection(hass)
-    try:
-        device_info = await keba.get_device_info(data[CONF_HOST])
-    except SetupError as exc:
-        raise CannotConnect from exc
+    host = data[CONF_HOST]
+    _LOGGER.debug("Validating input for host: %s", host)
 
-    # Return info that you want to store in the config entry.
-    return {"title": device_info.model, "unique_id": device_info.device_id}
+    # Detect device type
+    device_type = await detect_device_type(host)
+    _LOGGER.debug("Device type detected: %s", device_type)
+
+    if device_type == DEVICE_TYPE_P40:
+        # P40/P40 Pro device - use REST API
+        # For P40, we need a password. If not provided, try empty string
+        password = data.get(CONF_PASSWORD, "")
+        _LOGGER.debug("P40 device - attempting login with password: %s", "***" if password else "(empty)")
+
+        api_client = P40ApiClient(host)
+        try:
+            # Try to login
+            _LOGGER.debug("Calling api_client.login()...")
+            login_result = await api_client.login(password=password)
+            _LOGGER.debug("Login result: %s", login_result)
+
+            if not login_result:
+                _LOGGER.error("Login failed for P40 device at %s", host)
+                raise CannotConnect("Failed to authenticate with P40 device")
+
+            _LOGGER.debug("Login successful, getting device info...")
+            device_info = await api_client.get_device_info()
+            _LOGGER.debug("Device info retrieved: %s", device_info)
+
+            if not device_info:
+                _LOGGER.error("Failed to get device info from P40 at %s", host)
+                raise CannotConnect("Failed to get device info from P40")
+
+            await api_client.close()
+            _LOGGER.info("P40 validation successful for %s (model: %s, id: %s)",
+                        host, device_info.model, device_info.device_id)
+
+            return {
+                "title": device_info.model,
+                "unique_id": device_info.device_id,
+                "device_type": DEVICE_TYPE_P40,
+            }
+        except Exception as exc:
+            _LOGGER.error("Exception during P40 validation for %s: %s (type: %s)",
+                         host, str(exc), type(exc).__name__)
+            await api_client.close()
+            raise CannotConnect from exc
+    else:
+        # UDP-based device - use existing keba_kecontact library
+        keba = await get_keba_connection(hass)
+        try:
+            device_info = await keba.get_device_info(host)
+        except SetupError as exc:
+            raise CannotConnect from exc
+
+        # Return info that you want to store in the config entry.
+        return {
+            "title": device_info.model,
+            "unique_id": device_info.device_id,
+            "device_type": DEVICE_TYPE_UDP,
+        }
 
 
 class KebaConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -134,7 +232,10 @@ class KebaConfigFlow(ConfigFlow, domain=DOMAIN):
             if info:
                 await self.async_set_unique_id(info["unique_id"])
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=info["title"], data=user_input)
+                # Store device type in config entry data
+                entry_data = user_input.copy()
+                entry_data[CONF_DEVICE_TYPE] = info.get("device_type", DEVICE_TYPE_UDP)
+                return self.async_create_entry(title=info["title"], data=entry_data)
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_HOST_SCHEMA, errors=errors
@@ -146,16 +247,13 @@ class KebaConfigFlow(ConfigFlow, domain=DOMAIN):
         config_entry: ConfigEntry,
     ) -> KebaOptionsFlow:
         """Return a Keba options flow."""
-        return KebaOptionsFlow(config_entry)
+        return KebaOptionsFlow()
 
 
 class KebaOptionsFlow(OptionsFlow):
     """Handle a option flow for keba charging station."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize keba charging station option flow."""
-        self.config_entry = config_entry
-        self.options = dict(config_entry.options)
+    # No __init__ needed - framework provides self.config_entry automatically
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/keba/config_flow.py
+++ b/custom_components/keba/config_flow.py
@@ -46,8 +46,10 @@ async def detect_device_type(host: str) -> str:
     """Detect if the device is P40 (REST API) or older (UDP)."""
     _LOGGER.debug("Attempting to detect device type for host: %s", host)
 
-    # Try to connect to P40 REST API endpoint
-    # Note: /serialnumber returns plain text, not JSON
+    # Try to connect to P40 REST API endpoint.
+    # Note: /serialnumber returns plain text, not JSON.
+    # Firmware 2.4.0 (PKG-1.4.0) may return HTTP 500 from /serialnumber, so we
+    # also probe /version as a fallback to detect the P40 REST API.
     try:
         async with aiohttp.ClientSession() as session:
             async with asyncio.timeout(3):
@@ -67,7 +69,21 @@ async def detect_device_type(host: str) -> str:
                         _LOGGER.info("Detected P40 device at %s (auth required)", host)
                         return DEVICE_TYPE_P40
                     else:
-                        _LOGGER.debug("Unexpected status %s, assuming UDP device", response.status)
+                        _LOGGER.debug(
+                            "/serialnumber returned status %s, probing /version as fallback",
+                            response.status,
+                        )
+
+            async with asyncio.timeout(3):
+                async with session.get(
+                    f"https://{host}:8443/version",
+                    ssl=False,
+                ) as response:
+                    _LOGGER.debug("P40 /version response status: %s", response.status)
+                    if response.status in (200, 401):
+                        _LOGGER.info("Detected P40 device at %s via /version", host)
+                        return DEVICE_TYPE_P40
+                    _LOGGER.debug("Unexpected status %s, assuming UDP device", response.status)
     except asyncio.TimeoutError as err:
         _LOGGER.debug("P40 detection timeout for %s: %s", host, err)
     except aiohttp.ClientError as err:

--- a/custom_components/keba/const.py
+++ b/custom_components/keba/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Abfallplus integration."""
+"""Constants for the KEBA integration."""
 
 DOMAIN = "keba"
 CHARGING_STATIONS = "wallboxes"
@@ -7,3 +7,8 @@ DATA_HASS_CONFIG = "hass_config"
 
 CONF_RFID = "rfid"
 CONF_RFID_CLASS = "rfid_class"
+CONF_DEVICE_TYPE = "device_type"
+
+# Device types
+DEVICE_TYPE_UDP = "udp"
+DEVICE_TYPE_P40 = "p40"

--- a/custom_components/keba/lock.py
+++ b/custom_components/keba/lock.py
@@ -11,7 +11,16 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_RFID, CONF_RFID_CLASS, DOMAIN, KEBA_CONNECTION
+from .const import (
+    CHARGING_STATIONS,
+    CONF_DEVICE_TYPE,
+    CONF_RFID,
+    CONF_RFID_CLASS,
+    DEVICE_TYPE_P40,
+    DEVICE_TYPE_UDP,
+    DOMAIN,
+    KEBA_CONNECTION,
+)
 from .entity import KebaBaseEntity
 
 
@@ -21,10 +30,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the keba charging station locks from config entry."""
-    keba: KebaKeContact = hass.data[DOMAIN][KEBA_CONNECTION]
-    entities: list[KebaLock] = []
+    device_type = entry.data.get(CONF_DEVICE_TYPE, DEVICE_TYPE_UDP)
 
-    charging_station = keba.get_charging_station(entry.data[CONF_HOST])
+    if device_type == DEVICE_TYPE_P40:
+        charging_station = hass.data[DOMAIN][CHARGING_STATIONS][entry.entry_id]
+    else:
+        keba: KebaKeContact = hass.data[DOMAIN][KEBA_CONNECTION]
+        charging_station = keba.get_charging_station(entry.data[CONF_HOST])
+
+    entities: list[KebaLock] = []
     lock_description = LockEntityDescription(key="Authreq", name="Authentication")
 
     additional_args = {}

--- a/custom_components/keba/notify.py
+++ b/custom_components/keba/notify.py
@@ -10,7 +10,6 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
-    CHARGING_STATIONS,
     CONF_DEVICE_TYPE,
     DEVICE_TYPE_P40,
     DEVICE_TYPE_UDP,
@@ -28,11 +27,12 @@ async def async_setup_entry(
     """Set up the keba entity platform."""
     device_type = config_entry.data.get(CONF_DEVICE_TYPE, DEVICE_TYPE_UDP)
 
+    # P40 devices don't have a display, so skip notify entity
     if device_type == DEVICE_TYPE_P40:
-        charging_station = hass.data[DOMAIN][CHARGING_STATIONS][config_entry.entry_id]
-    else:
-        keba = hass.data[DOMAIN][KEBA_CONNECTION]
-        charging_station = keba.get_charging_station(config_entry.data[CONF_HOST])
+        return
+
+    keba = hass.data[DOMAIN][KEBA_CONNECTION]
+    charging_station = keba.get_charging_station(config_entry.data[CONF_HOST])
     async_add_entities(
         [
             KebaNotifyEntity(

--- a/custom_components/keba/notify.py
+++ b/custom_components/keba/notify.py
@@ -9,7 +9,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN, KEBA_CONNECTION
+from .const import (
+    CHARGING_STATIONS,
+    CONF_DEVICE_TYPE,
+    DEVICE_TYPE_P40,
+    DEVICE_TYPE_UDP,
+    DOMAIN,
+    KEBA_CONNECTION,
+)
 from .entity import KebaBaseEntity
 
 
@@ -19,9 +26,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the keba entity platform."""
+    device_type = config_entry.data.get(CONF_DEVICE_TYPE, DEVICE_TYPE_UDP)
 
-    keba = hass.data[DOMAIN][KEBA_CONNECTION]
-    charging_station = keba.get_charging_station(config_entry.data[CONF_HOST])
+    if device_type == DEVICE_TYPE_P40:
+        charging_station = hass.data[DOMAIN][CHARGING_STATIONS][config_entry.entry_id]
+    else:
+        keba = hass.data[DOMAIN][KEBA_CONNECTION]
+        charging_station = keba.get_charging_station(config_entry.data[CONF_HOST])
     async_add_entities(
         [
             KebaNotifyEntity(

--- a/custom_components/keba/number.py
+++ b/custom_components/keba/number.py
@@ -9,7 +9,14 @@ from homeassistant.const import CONF_HOST, UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, KEBA_CONNECTION
+from .const import (
+    CHARGING_STATIONS,
+    CONF_DEVICE_TYPE,
+    DEVICE_TYPE_P40,
+    DEVICE_TYPE_UDP,
+    DOMAIN,
+    KEBA_CONNECTION,
+)
 from .entity import KebaBaseEntity
 
 
@@ -19,10 +26,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Keba charging station number from config entry."""
-    keba: KebaKeContact = hass.data[DOMAIN][KEBA_CONNECTION]
-    entities: list[KebaNumber] = []
+    device_type = config_entry.data.get(CONF_DEVICE_TYPE, DEVICE_TYPE_UDP)
 
-    charging_station = keba.get_charging_station(config_entry.data[CONF_HOST])
+    if device_type == DEVICE_TYPE_P40:
+        charging_station = hass.data[DOMAIN][CHARGING_STATIONS][config_entry.entry_id]
+    else:
+        keba: KebaKeContact = hass.data[DOMAIN][KEBA_CONNECTION]
+        charging_station = keba.get_charging_station(config_entry.data[CONF_HOST])
+
+    entities: list[KebaNumber] = []
     number_description = NumberEntityDescription(
         key="Curr user",
         name="Charging current",

--- a/custom_components/keba/p40_api.py
+++ b/custom_components/keba/p40_api.py
@@ -1,0 +1,530 @@
+"""REST API client for KEBA P40/P40 Pro charging stations."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+import logging
+from typing import Any
+
+import aiohttp
+import async_timeout
+
+_LOGGER = logging.getLogger(__name__)
+
+# API timeout in seconds
+API_TIMEOUT = 10
+
+
+@dataclass
+class P40DeviceInfo:
+    """Device information for P40/P40 Pro charging station."""
+
+    device_id: str
+    manufacturer: str = "KEBA"
+    model: str = ""
+    sw_version: str = ""
+    webconfigurl: str = ""
+
+    def available_services(self) -> list:
+        """Return available services (for compatibility with UDP-based devices)."""
+        # P40 devices support basic start/stop services
+        return []  # Services are registered differently for P40
+
+
+@dataclass
+class P40MeterInfo:
+    """Meter information from P40 charging station."""
+
+    meter_value: int  # mWh
+    total_active_power: int  # mW
+    total_power_factor: int  # cos phi * 10^3
+    phases_supported: int
+    current_offered: int  # mA
+    temperature: int  # hundredths of degree Celsius
+    lines: list[dict[str, Any]]
+
+
+@dataclass
+class P40WallboxState:
+    """State information for P40 wallbox."""
+
+    number: int
+    serial_number: str
+    state: str
+    vehicle_plugged: bool
+    authorization_enabled: bool
+    session_active: bool
+    meter: P40MeterInfo | None
+    max_phases: int
+    max_current: int  # mA
+    phase_used: str
+    ip_address: str
+    model: str
+    firmware_version: str | None
+    error_code: str | None
+    alias: str | None
+    # Optional fields that may or may not be present in API response
+    x2active: bool = False
+    x11active: bool = False
+    x12active: bool = False
+    permanently_locked: bool = False
+
+
+@dataclass
+class P40SessionInfo:
+    """Session information from P40 charging station."""
+
+    id: int  # sessionSequenceId
+    wallbox_number: int
+    wallbox_serial_number: str
+    wallbox_alias: str | None
+    status: str
+    starting_meter_value: int  # mWh
+    start_date: int  # unix timestamp
+    energy_consumed: int  # mWh
+    energy_consumed_in_kwh: float | None  # kWh
+    duration: int | None  # milliseconds
+    token_id: str | None  # RFID token
+    ending_meter_value: int | None  # mWh
+    end_date: int | None  # unix timestamp
+    termination_reason: str | None
+    transaction_token: str | None
+
+
+class P40ApiClient:
+    """REST API client for KEBA P40/P40 Pro charging stations."""
+
+    def __init__(self, host: str, session: aiohttp.ClientSession | None = None) -> None:
+        """Initialize the P40 API client."""
+        self._host = host
+        self._session = session
+        self._own_session = session is None
+        self._base_url = f"https://{host}:8443"
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        self._callbacks: list = []
+        # Store credentials for re-authentication
+        self._username: str | None = None
+        self._password: str | None = None
+        self._is_refreshing: bool = False
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        """Ensure we have an aiohttp session."""
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        """Close the API client."""
+        if self._own_session and self._session:
+            await self._session.close()
+            self._session = None
+
+    async def login(self, username: str = "admin", password: str = "") -> bool:
+        """Login to the P40 charging station."""
+        _LOGGER.info("Attempting login to P40 at %s with username=%s", self._base_url, username)
+        # Store credentials for token refresh/re-authentication
+        self._username = username
+        self._password = password
+
+        session = await self._ensure_session()
+        url = f"{self._base_url}/v2/jwt/login"
+
+        try:
+            async with async_timeout.timeout(API_TIMEOUT):
+                _LOGGER.info("Sending login request to %s", url)
+                async with session.post(
+                    url,
+                    json={"username": username, "password": password},
+                    ssl=False,  # P40 uses self-signed certificates
+                ) as response:
+                    _LOGGER.info("Login response status: %s", response.status)
+                    if response.status == 200:
+                        data = await response.json()
+                        self._access_token = data.get("accessToken")
+                        self._refresh_token = data.get("refreshToken")
+                        _LOGGER.info("Login successful, access_token present: %s", bool(self._access_token))
+                        return True
+                    else:
+                        response_text = await response.text()
+                        _LOGGER.error("Login failed with status %s, response: %s", response.status, response_text)
+                        return False
+        except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+            _LOGGER.error("Error during login: %s (type: %s)", err, type(err).__name__, exc_info=True)
+            return False
+
+    async def _refresh_access_token(self) -> bool:
+        """Refresh the access token using the refresh token."""
+        if not self._refresh_token:
+            _LOGGER.warning("No refresh token available, attempting full re-login")
+            if self._username and self._password:
+                return await self.login(self._username, self._password)
+            return False
+
+        _LOGGER.info("Attempting to refresh access token")
+        session = await self._ensure_session()
+        url = f"{self._base_url}/v2/jwt/refresh"
+
+        try:
+            async with async_timeout.timeout(API_TIMEOUT):
+                async with session.post(
+                    url,
+                    headers={"Authorization": f"Bearer {self._refresh_token}"},
+                    ssl=False,
+                ) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        self._access_token = data.get("accessToken")
+                        # Refresh token endpoint may also return a new refresh token
+                        new_refresh = data.get("refreshToken")
+                        if new_refresh:
+                            self._refresh_token = new_refresh
+                        _LOGGER.info("Token refresh successful")
+                        return True
+                    else:
+                        response_text = await response.text()
+                        _LOGGER.warning(
+                            "Token refresh failed with status %s: %s, attempting full re-login",
+                            response.status, response_text
+                        )
+                        # Refresh token might be expired, try full re-login
+                        if self._username and self._password:
+                            return await self.login(self._username, self._password)
+                        return False
+        except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+            _LOGGER.error("Error during token refresh: %s", err)
+            # Try full re-login on error
+            if self._username and self._password:
+                return await self.login(self._username, self._password)
+            return False
+
+    async def _request(
+        self, method: str, path: str, json_data: dict | None = None, params: dict | None = None,
+        _retry_on_401: bool = True
+    ) -> dict | None:
+        """Make an authenticated request to the API.
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            path: API path
+            json_data: Optional JSON body data
+            params: Optional query parameters
+            _retry_on_401: Internal flag to prevent infinite retry loops
+        """
+        _LOGGER.debug("_request called: method=%s, path=%s, has_json_data=%s, has_params=%s",
+                     method, path, json_data is not None, params is not None)
+
+        if not self._access_token:
+            _LOGGER.error("Not authenticated. Please login first.")
+            return None
+
+        _LOGGER.debug("Access token present, making request to %s", path)
+        session = await self._ensure_session()
+        url = f"{self._base_url}{path}"
+        headers = {"Authorization": f"Bearer {self._access_token}"}
+
+        try:
+            async with async_timeout.timeout(API_TIMEOUT):
+                _LOGGER.debug("Sending %s request to %s with params=%s", method, url, params)
+                async with session.request(
+                    method, url, json=json_data, headers=headers, ssl=False, params=params
+                ) as response:
+                    _LOGGER.debug("Response from %s: status=%s", path, response.status)
+                    if response.status in (200, 201):
+                        response_data = await response.json()
+                        _LOGGER.debug("Response data from %s: %s", path, response_data)
+                        return response_data
+                    elif response.status == 401 and _retry_on_401:
+                        # Token expired, try to refresh
+                        response_text = await response.text()
+                        _LOGGER.warning(
+                            "Request to %s got 401 (token expired): %s. Attempting token refresh...",
+                            path, response_text
+                        )
+                        if await self._refresh_access_token():
+                            _LOGGER.info("Token refreshed successfully, retrying request to %s", path)
+                            # Retry the request with the new token (but don't retry again on 401)
+                            return await self._request(method, path, json_data, params, _retry_on_401=False)
+                        else:
+                            _LOGGER.error("Token refresh failed, cannot complete request to %s", path)
+                            return None
+                    else:
+                        response_text = await response.text()
+                        _LOGGER.error(
+                            "Request to %s failed with status %s, response: %s",
+                            path, response.status, response_text
+                        )
+                        return None
+        except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+            _LOGGER.error("Error during request to %s: %s (type: %s)",
+                         path, err, type(err).__name__, exc_info=True)
+            return None
+
+    async def get_device_info(self) -> P40DeviceInfo | None:
+        """Get device information."""
+        # Get serial number - Note: /serialnumber returns plain text, not JSON
+        session = await self._ensure_session()
+        url = f"{self._base_url}/serialnumber"
+
+        try:
+            async with async_timeout.timeout(API_TIMEOUT):
+                async with session.get(url, ssl=False) as response:
+                    if response.status == 200:
+                        serial_number = (await response.text()).strip()
+                    else:
+                        _LOGGER.error(
+                            "Request to /serialnumber failed with status %s", response.status
+                        )
+                        return None
+        except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+            _LOGGER.error("Error during request to /serialnumber: %s", err)
+            return None
+
+        # Get version info - Note: /version returns a JSON string (e.g., "2.3.0-SNAPSHOT")
+        version = ""
+        try:
+            async with async_timeout.timeout(API_TIMEOUT):
+                async with session.get(f"{self._base_url}/version", ssl=False) as response:
+                    if response.status == 200:
+                        version = await response.json()  # Returns a JSON string
+                    else:
+                        _LOGGER.warning(
+                            "Request to /version failed with status %s", response.status
+                        )
+        except (asyncio.TimeoutError, aiohttp.ClientError) as err:
+            _LOGGER.warning("Error during request to /version: %s", err)
+
+        # Get wallbox info to get model
+        wallboxes = await self._request("GET", "/v2/wallboxes")
+        model = ""
+        if wallboxes and isinstance(wallboxes, list) and len(wallboxes) > 0:
+            model = wallboxes[0].get("model", "")
+
+        return P40DeviceInfo(
+            device_id=serial_number,
+            model=model or "KEBA P40",
+            sw_version=version,
+            webconfigurl=f"https://{self._host}:8443",
+        )
+
+    async def get_wallbox(self, serial_number: str | None = None) -> dict | None:
+        """Get wallbox information."""
+        _LOGGER.debug("get_wallbox called with serial_number=%s", serial_number)
+        if serial_number:
+            _LOGGER.debug("Getting specific wallbox: %s", serial_number)
+            result = await self._request("GET", f"/v2/wallboxes/{serial_number}")
+            _LOGGER.debug("Specific wallbox response: %s", result)
+            return result
+        else:
+            # Get first wallbox
+            _LOGGER.debug("Getting all wallboxes from /v2/wallboxes")
+            response = await self._request("GET", "/v2/wallboxes")
+            _LOGGER.debug("Wallboxes response: %s (type: %s)", response, type(response).__name__)
+
+            # Response is a dict with 'wallboxes' key containing the list
+            if response and isinstance(response, dict):
+                wallboxes = response.get("wallboxes", [])
+                if wallboxes and len(wallboxes) > 0:
+                    _LOGGER.debug("Returning first wallbox: %s", wallboxes[0])
+                    return wallboxes[0]
+            # Fallback: check if response is directly a list (for compatibility)
+            elif response and isinstance(response, list) and len(response) > 0:
+                _LOGGER.debug("Returning first wallbox from list: %s", response[0])
+                return response[0]
+
+            _LOGGER.warning("No wallboxes found in response, response=%s", response)
+            return None
+
+    async def get_wallbox_state(self, serial_number: str) -> P40WallboxState | None:
+        """Get current wallbox state."""
+        data = await self.get_wallbox(serial_number)
+        if not data:
+            return None
+
+        # Parse meter info
+        meter_data = data.get("meter")
+        meter = None
+        if meter_data:
+            meter = P40MeterInfo(
+                meter_value=meter_data.get("meterValue", 0),
+                total_active_power=meter_data.get("totalActivePower", 0),
+                total_power_factor=meter_data.get("totalPowerFactor", 0),
+                phases_supported=meter_data.get("phasesSupported", 0),
+                current_offered=meter_data.get("currentOffered", 0),
+                temperature=meter_data.get("temperature", 0),
+                lines=meter_data.get("lines", []),
+            )
+
+        return P40WallboxState(
+            number=data.get("number", 1),
+            serial_number=data.get("serialNumber", serial_number),
+            state=data.get("state", "UNKNOWN"),
+            vehicle_plugged=data.get("vehiclePlugged", False),
+            authorization_enabled=data.get("authorizationEnabled", False),
+            session_active=data.get("sessionActive", False),
+            meter=meter,
+            max_phases=data.get("maxPhases", 3),
+            max_current=data.get("maxCurrent", 0),
+            phase_used=data.get("phaseUsed", ""),
+            ip_address=data.get("ipAddress", ""),
+            model=data.get("model", ""),
+            firmware_version=data.get("firmwareVersion"),
+            error_code=data.get("errorCode"),
+            alias=data.get("alias"),
+            # Optional fields
+            x2active=data.get("x2active", False),
+            x11active=data.get("x11active", False),
+            x12active=data.get("x12active", False),
+            permanently_locked=data.get("permanentlyLocked", False),
+        )
+
+    async def start_charging(self, serial_number: str, token_id: str | None = None) -> bool:
+        """Start charging."""
+        json_data = {}
+        if token_id:
+            json_data["tokenId"] = token_id
+
+        result = await self._request(
+            "POST", f"/v2/wallboxes/{serial_number}/start-charging", json_data
+        )
+        return result is not None
+
+    async def stop_charging(self, serial_number: str) -> bool:
+        """Stop charging."""
+        result = await self._request("POST", f"/v2/wallboxes/{serial_number}/stop-charging")
+        return result is not None
+
+    async def get_load_management_config(self, key: str | None = None) -> dict | None:
+        """Get load management configuration.
+
+        Args:
+            key: Specific config key to get, or None to get all configs.
+                 Available keys: max_available_current, min_default_current,
+                 nominal_voltage, nominal_frequency, failsafe_current_serial_1, etc.
+
+        Returns:
+            Configuration value(s) or None on error.
+        """
+        if key:
+            return await self._request("GET", f"/v2/configs/lmgmt/{key}")
+        return await self._request("GET", "/v2/configs/lmgmt/")
+
+    async def set_load_management_config(self, configs: list[dict]) -> bool:
+        """Set load management configuration.
+
+        Args:
+            configs: List of config dicts with 'key' and 'value'.
+                     Example: [{"key": "max_available_current", "value": 8000}]
+                     Available keys: max_available_current, min_default_current,
+                     failsafe_current_serial_1, etc. Values in mA for currents.
+
+        Returns:
+            True if successful, False otherwise.
+        """
+        json_data = {"configs": configs}
+        result = await self._request("PUT", "/v2/configs/lmgmt/", json_data)
+        return result is not None
+
+    def _parse_session(self, data: dict) -> P40SessionInfo:
+        """Parse session data from API response."""
+        return P40SessionInfo(
+            id=data.get("id", 0),
+            wallbox_number=data.get("wallboxNumber", 0),
+            wallbox_serial_number=data.get("wallboxSerialNumber", ""),
+            wallbox_alias=data.get("wallboxAlias"),
+            status=data.get("status", ""),
+            starting_meter_value=data.get("startingMeterValue", 0),
+            start_date=data.get("startDate", 0),
+            energy_consumed=data.get("energyConsumed", 0),
+            energy_consumed_in_kwh=data.get("energyConsumedInKwh"),
+            duration=data.get("duration"),
+            token_id=data.get("tokenId"),
+            ending_meter_value=data.get("endingMeterValue"),
+            end_date=data.get("endDate"),
+            termination_reason=data.get("terminationReason"),
+            transaction_token=data.get("transactionToken"),
+        )
+
+    async def get_sessions(
+        self,
+        serial_number: str | None = None,
+        limit: int = 10,
+        order_field: str = "SESSION_START_DATE",
+        order_dir: str = "DESC",
+    ) -> list[P40SessionInfo]:
+        """Get charging sessions.
+
+        Args:
+            serial_number: Filter by wallbox serial number
+            limit: Maximum number of sessions to return
+            order_field: Field to order by (default: SESSION_START_DATE)
+            order_dir: Order direction ASC or DESC (default: DESC)
+
+        Returns:
+            List of P40SessionInfo objects
+        """
+        params = {
+            "limit": str(limit),
+            "orderField": order_field,
+            "orderDir": order_dir,
+        }
+        if serial_number:
+            params["filters"] = f"SOCKET_SERIAL_NUMBER={serial_number}"
+
+        data = await self._request("GET", "/v2/sessions", params=params)
+        if not data:
+            return []
+
+        # API returns {'sessions': [...]} not a direct list
+        sessions_list = data.get("sessions", []) if isinstance(data, dict) else data
+        if not isinstance(sessions_list, list):
+            return []
+
+        return [self._parse_session(session) for session in sessions_list]
+
+    async def get_current_session(self, serial_number: str) -> P40SessionInfo | None:
+        """Get current active charging session for a wallbox.
+
+        Args:
+            serial_number: Wallbox serial number
+
+        Returns:
+            P40SessionInfo if an active session exists, None otherwise
+        """
+        sessions = await self.get_sessions(serial_number, limit=5)
+        for session in sessions:
+            if (
+                session.wallbox_serial_number == serial_number
+                and session.status in ["INITIATED", "PWM_CHARGING", "BLOCKED"]
+            ):
+                return session
+        return None
+
+    def add_callback(self, callback) -> None:
+        """Add a callback for state updates."""
+        self._callbacks.append(callback)
+
+    def remove_callback(self, callback) -> None:
+        """Remove a callback."""
+        if callback in self._callbacks:
+            self._callbacks.remove(callback)
+
+    async def start_polling(self, serial_number: str, interval: int = 5) -> None:
+        """Start polling for updates (for compatibility with UDP-based implementation)."""
+        # This would be implemented to periodically poll the API
+        # For now, this is a placeholder
+        pass
+
+    async def unlock_socket(self, serial_number: str) -> bool:
+        """Unlock the charging socket (only for socket/plug versions, not cable versions).
+
+        Args:
+            serial_number: The serial number of the wallbox
+
+        Returns:
+            True if successful, False otherwise
+        """
+        result = await self._request("POST", f"/v2/wallboxes/{serial_number}/unlock")
+        return result is not None

--- a/custom_components/keba/p40_api.py
+++ b/custom_components/keba/p40_api.py
@@ -265,22 +265,29 @@ class P40ApiClient:
     async def get_device_info(self) -> P40DeviceInfo | None:
         """Get device information."""
         # Get serial number - Note: /serialnumber returns plain text, not JSON
+        # In firmware 2.4.0 (PKG-1.4.0) this endpoint may return HTTP 500;
+        # in that case we fall back to the wallbox serial number from /v2/wallboxes.
         session = await self._ensure_session()
         url = f"{self._base_url}/serialnumber"
 
+        serial_number: str | None = None
         try:
             async with async_timeout.timeout(API_TIMEOUT):
                 async with session.get(url, ssl=False) as response:
                     if response.status == 200:
                         serial_number = (await response.text()).strip()
                     else:
-                        _LOGGER.error(
-                            "Request to /serialnumber failed with status %s", response.status
+                        _LOGGER.warning(
+                            "Request to /serialnumber failed with status %s, "
+                            "falling back to wallbox serial number",
+                            response.status,
                         )
-                        return None
         except (asyncio.TimeoutError, aiohttp.ClientError) as err:
-            _LOGGER.error("Error during request to /serialnumber: %s", err)
-            return None
+            _LOGGER.warning(
+                "Error during request to /serialnumber: %s, "
+                "falling back to wallbox serial number",
+                err,
+            )
 
         # Get version info - Note: /version returns a JSON string (e.g., "2.3.0-SNAPSHOT")
         version = ""
@@ -296,11 +303,25 @@ class P40ApiClient:
         except (asyncio.TimeoutError, aiohttp.ClientError) as err:
             _LOGGER.warning("Error during request to /version: %s", err)
 
-        # Get wallbox info to get model
-        wallboxes = await self._request("GET", "/v2/wallboxes")
+        # Get wallbox info to get model and (optionally) the serial number fallback
+        wallboxes_response = await self._request("GET", "/v2/wallboxes")
+        wallboxes: list = []
+        if isinstance(wallboxes_response, dict):
+            wallboxes = wallboxes_response.get("wallboxes", []) or []
+        elif isinstance(wallboxes_response, list):
+            wallboxes = wallboxes_response
+
         model = ""
-        if wallboxes and isinstance(wallboxes, list) and len(wallboxes) > 0:
+        if wallboxes:
             model = wallboxes[0].get("model", "")
+            if not serial_number:
+                serial_number = wallboxes[0].get("serialNumber") or None
+
+        if not serial_number:
+            _LOGGER.error(
+                "Unable to determine device serial number from /serialnumber or /v2/wallboxes"
+            )
+            return None
 
         return P40DeviceInfo(
             device_id=serial_number,

--- a/custom_components/keba/p40_charging_station.py
+++ b/custom_components/keba/p40_charging_station.py
@@ -1,0 +1,351 @@
+"""P40/P40 Pro charging station wrapper for Home Assistant integration."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from .p40_api import P40ApiClient, P40DeviceInfo, P40SessionInfo
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class P40ChargingStation:
+    """Wrapper for P40/P40 Pro charging station to match the interface of UDP-based stations."""
+
+    def __init__(self, api_client: P40ApiClient, serial_number: str) -> None:
+        """Initialize the P40 charging station."""
+        self._api = api_client
+        self._serial_number = serial_number
+        self._device_info: P40DeviceInfo | None = None
+        self._state_cache: dict[str, Any] = {}
+        self._callbacks: list = []
+        self._polling_task: asyncio.Task | None = None
+        self._polling_interval = 5  # seconds
+        self._current_session: P40SessionInfo | None = None
+        self._last_completed_session: P40SessionInfo | None = None
+        self._max_available_current: int | None = None  # in mA, from load management config
+
+    @property
+    def device_info(self) -> P40DeviceInfo:
+        """Return device information."""
+        return self._device_info
+
+    async def initialize(self) -> None:
+        """Initialize the charging station."""
+        self._device_info = await self._api.get_device_info()
+        await self._update_state()
+        # Start polling for updates
+        self._polling_task = asyncio.create_task(self._poll_updates())
+
+    async def _update_state(self) -> None:
+        """Update the state cache from the API."""
+        state = await self._api.get_wallbox_state(self._serial_number)
+        if not state:
+            return
+
+        # Get load management config for max_available_current
+        lmgmt_config = await self._api.get_load_management_config("max_available_current")
+        if lmgmt_config and "data" in lmgmt_config:
+            # Store max_available_current in mA, will be converted to A when used
+            self._max_available_current = lmgmt_config["data"]
+
+        # Get current session data
+        self._current_session = await self._api.get_current_session(self._serial_number)
+        _LOGGER.debug("Current session for %s: %s", self._serial_number, self._current_session)
+
+        # Get last completed session for historical data (ended, reason)
+        # Need to fetch more than 1 session to find a completed one (the first might be active)
+        sessions = await self._api.get_sessions(self._serial_number, limit=5)
+        _LOGGER.debug("All sessions for %s: %s", self._serial_number, sessions)
+        if sessions:
+            # Get the most recent session that has an end date (completed session)
+            for session in sessions:
+                _LOGGER.debug("Checking session %s: status=%s, end_date=%s", session.id, session.status, session.end_date)
+                if session.end_date is not None and session.status == "CLOSED":
+                    self._last_completed_session = session
+                    _LOGGER.debug("Found last completed session: %s", session)
+                    break
+        _LOGGER.debug("Last completed session: %s", self._last_completed_session)
+
+        # Map P40 state to the format expected by entities
+        # This mapping ensures compatibility with existing entity code
+        
+        # Basic state
+        self._state_cache["State"] = self._map_state(state.state)
+        self._state_cache["State_details"] = self._map_state_details(state.state)
+        self._state_cache["Plug"] = 7 if state.vehicle_plugged else 0
+        
+        # Meter values
+        if state.meter:
+            # meterValue is total energy (like odometer), convert mWh to kWh
+            self._state_cache["E total"] = state.meter.meter_value / 1000000
+            # Convert mW to kW (sensor expects kW)
+            self._state_cache["P"] = state.meter.total_active_power / 1000000
+            # Convert mA to A - currentOffered is what's being offered to the vehicle right now
+            self._state_cache["Curr offered"] = state.meter.current_offered / 1000
+            # For Curr user (used by Number entity), use max_available_current from load management
+            # This is the configured max current, not the current being offered
+            if self._max_available_current is not None:
+                self._state_cache["Curr user"] = self._max_available_current / 1000
+            else:
+                # Fallback to currentOffered if load management config not available
+                self._state_cache["Curr user"] = state.meter.current_offered / 1000
+            self._state_cache["Curr HW"] = state.max_current / 1000
+            # Power factor (cos phi * 1000, convert to decimal)
+            self._state_cache["PF"] = state.meter.total_power_factor / 1000
+
+            # P40-specific: Temperature in hundredths of degree to degrees
+            self._state_cache["Temperature"] = state.meter.temperature / 100
+
+            # P40-specific: Phases supported
+            self._state_cache["Phases Supported"] = state.meter.phases_supported
+
+            # Phase currents and voltages
+            for i, line in enumerate(state.meter.lines[:3], 1):
+                phase = line.get("socketPhase", f"L{i}")
+                # Convert mA to A
+                self._state_cache[f"I{i}"] = line.get("current", 0) / 1000
+                self._state_cache[f"U{i}"] = line.get("voltage", 0)
+        
+        # Max current and percentage
+        self._state_cache["Max curr"] = state.max_current / 1000  # Convert mA to A
+        if state.max_current > 0:
+            curr_user = self._state_cache.get("Curr user", 0)
+            self._state_cache["Max curr %"] = (curr_user / (state.max_current / 1000)) * 100
+
+        # Digital outputs and inputs (optional fields in P40 API)
+        self._state_cache["Output"] = 1 if state.x11active else 0
+        self._state_cache["Input"] = 1 if state.x12active else 0
+
+        # X2 phase switch
+        self._state_cache["X2 phaseSwitch"] = 1 if state.x2active else 0
+
+        # Plug locked status
+        self._state_cache["Plug_locked"] = state.permanently_locked
+
+        # Binary sensor states
+        self._state_cache["State_on"] = state.state == "CHARGING"
+        self._state_cache["Plug_EV"] = state.vehicle_plugged
+        self._state_cache["Plug_charging_station"] = state.vehicle_plugged
+        self._state_cache["AuthON"] = state.authorization_enabled
+
+        # P40-specific: Session active binary sensor
+        self._state_cache["Session Active"] = state.session_active
+
+        # Session info
+        self._state_cache["Session ID"] = self._current_session.id if self._current_session else None
+        self._state_cache["RFID tag"] = self._current_session.token_id if self._current_session else None
+        self._state_cache["RFID class"] = None  # Not available in P40 API
+        self._state_cache["E start"] = self._current_session.starting_meter_value / 1000000 if self._current_session else None  # Convert mWh to kWh
+        # Convert timestamps from milliseconds to datetime objects (truncate to seconds)
+        if self._current_session and self._current_session.start_date:
+            self._state_cache["started"] = datetime.fromtimestamp(
+                self._current_session.start_date // 1000, tz=timezone.utc
+            ).isoformat()
+        else:
+            self._state_cache["started"] = None
+        if self._last_completed_session and self._last_completed_session.end_date:
+            self._state_cache["ended"] = datetime.fromtimestamp(
+                self._last_completed_session.end_date // 1000, tz=timezone.utc
+            ).isoformat()
+        else:
+            self._state_cache["ended"] = None
+        self._state_cache["reason"] = self._last_completed_session.termination_reason if self._last_completed_session else None
+
+        # Session energy - always use energyConsumed with conversion since energyConsumedInKwh can be 0.0
+        if self._current_session:
+            self._state_cache["E pres"] = self._current_session.energy_consumed / 1000000  # mWh to kWh
+        else:
+            self._state_cache["E pres"] = 0
+
+        _LOGGER.debug(
+            "Session state cache: Session ID=%s, started=%s, ended=%s, reason=%s, E pres=%s",
+            self._state_cache.get("Session ID"),
+            self._state_cache.get("started"),
+            self._state_cache.get("ended"),
+            self._state_cache.get("reason"),
+            self._state_cache.get("E pres"),
+        )
+
+        # Authorization - for P40, use session_active to determine if charging is authorized
+        # Authreq=1 means "authorization required" (locked), Authreq=0 means "authorized" (unlocked)
+        # So we invert session_active: if session is active, we're authorized (Authreq=0)
+        self._state_cache["Authreq"] = 0 if state.session_active else 1
+        # Also store the actual authorization_enabled setting
+        self._state_cache["AuthON"] = state.authorization_enabled
+
+        # P40-specific sensors
+        # Raw state from API
+        self._state_cache["Raw State"] = state.state
+        # Phase used
+        self._state_cache["Phase Used"] = state.phase_used
+        # Model
+        self._state_cache["Model"] = state.model
+        # Error code (always set, even if None)
+        self._state_cache["Error Code"] = state.error_code
+        # Firmware version (always set, even if None)
+        self._state_cache["Firmware Version"] = state.firmware_version
+
+        # Notify callbacks
+        for callback in self._callbacks:
+            try:
+                callback()
+            except Exception as err:
+                _LOGGER.error("Error in callback: %s", err)
+
+    def _map_state(self, p40_state: str) -> int:
+        """Map P40 state to legacy state codes."""
+        state_mapping = {
+            "IDLE": 0,
+            "READY_FOR_CHARGING": 1,
+            "CHARGING": 3,
+            "SUSPENDED": 4,
+            "RECOVER_FROM_ERROR": 5,
+            "UNAVAILABLE": 254,
+            "OFFLINE": 254,
+        }
+        return state_mapping.get(p40_state, 0)
+
+    def _map_state_details(self, p40_state: str) -> str:
+        """Map P40 state to human-readable string."""
+        state_details = {
+            "IDLE": "ready",
+            "READY_FOR_CHARGING": "ready",
+            "CHARGING": "charging",
+            "SUSPENDED": "suspended",
+            "RECOVER_FROM_ERROR": "error",
+            "UNAVAILABLE": "unavailable",
+            "OFFLINE": "offline",
+            "INSTALLER_MODE": "installer mode",
+            "TOKEN_PROGRAMMING_MODE": "token programming",
+            "UNRECOVERABLE_ERROR": "error",
+            "DEGRADED": "degraded",
+        }
+        return state_details.get(p40_state, "unknown")
+
+    async def _poll_updates(self) -> None:
+        """Poll for state updates."""
+        while True:
+            try:
+                await asyncio.sleep(self._polling_interval)
+                await self._update_state()
+            except asyncio.CancelledError:
+                break
+            except Exception as err:
+                _LOGGER.error("Error polling updates: %s", err)
+
+    def get_value(self, key: str) -> Any:
+        """Get a cached value."""
+        return self._state_cache.get(key)
+
+    def add_callback(self, callback) -> None:
+        """Add a callback for state updates."""
+        self._callbacks.append(callback)
+
+    def remove_callback(self, callback) -> None:
+        """Remove a callback."""
+        if callback in self._callbacks:
+            self._callbacks.remove(callback)
+
+    async def start(self, rfid: str | None = None, rfid_class: str | None = None) -> None:
+        """Start charging."""
+        # P40 uses token_id instead of RFID
+        token_id = rfid if rfid else None
+        await self._api.start_charging(self._serial_number, token_id)
+        # Update state immediately
+        await self._update_state()
+
+    async def stop(self, rfid: str | None = None, rfid_class: str | None = None) -> None:
+        """Stop charging."""
+        await self._api.stop_charging(self._serial_number)
+        # Update state immediately
+        await self._update_state()
+
+    async def enable(self) -> None:
+        """Enable charging (same as start without RFID)."""
+        await self._api.start_charging(self._serial_number)
+        # Update state immediately
+        await self._update_state()
+
+    async def disable(self) -> None:
+        """Disable charging (same as stop)."""
+        await self._api.stop_charging(self._serial_number)
+        # Update state immediately
+        await self._update_state()
+
+    async def unlock_socket(self) -> None:
+        """Unlock the charging socket."""
+        await self._api.unlock_socket(self._serial_number)
+        # Update state immediately
+        await self._update_state()
+
+    async def request_data(self) -> None:
+        """Request updated data from the charging station."""
+        await self._update_state()
+
+    async def display(self, message: str) -> None:
+        """Display a message on the charging station (not supported on P40)."""
+        raise NotImplementedError("P40/P40 Pro does not support display text functionality via API")
+
+    async def set_current_max_permanent(self, current: float) -> None:
+        """Set maximum available current permanently."""
+        # Convert A to mA
+        current_ma = int(current * 1000)
+        configs = [{"key": "max_available_current", "value": current_ma}]
+        await self._api.set_load_management_config(configs)
+        await self._update_state()
+
+    async def set_current(self, current: float, delay: int | None = None) -> None:
+        """Set charging current limit."""
+        # Convert A to mA
+        current_ma = int(current * 1000)
+        configs = [{"key": "max_available_current", "value": current_ma}]
+        await self._api.set_load_management_config(configs)
+        await self._update_state()
+
+    async def set_failsafe(self, timeout: int, fallback_value: float) -> None:
+        """Configure failsafe mode."""
+        # Convert A to mA
+        fallback_ma = int(fallback_value * 1000)
+        configs = [{"key": "failsafe_current_serial_1", "value": fallback_ma}]
+        await self._api.set_load_management_config(configs)
+        await self._update_state()
+
+    async def set_energy(self, energy: float) -> None:
+        """Set energy limit - NOT SUPPORTED on P40."""
+        raise NotImplementedError("P40/P40 Pro does not support setting energy limits via API")
+
+    async def set_charging_power(self, power: float) -> None:
+        """Set charging power - NOT SUPPORTED on P40."""
+        raise NotImplementedError("P40/P40 Pro does not support setting power limits via API (only current limits)")
+
+    async def set_output(self, value: int) -> None:
+        """Set output value on X2."""
+        configs = [{"key": "inst_x2_mode", "value": value}]
+        await self._api.set_installer_io_config(configs)
+        await self._update_state()
+
+    async def x2src(self, source: int) -> None:
+        """Set X2 source."""
+        configs = [{"key": "connector_phase_source", "value": source}]
+        await self._api.set_load_management_config(configs)
+        await self._update_state()
+
+    async def x2(self, three_phases: bool) -> None:
+        """X2 Phase switch."""
+        configs = [{"key": "connector_phase_enable", "value": three_phases}]
+        await self._api.set_load_management_config(configs)
+        await self._update_state()
+
+    async def close(self) -> None:
+        """Close the charging station connection."""
+        if self._polling_task:
+            self._polling_task.cancel()
+            try:
+                await self._polling_task
+            except asyncio.CancelledError:
+                pass
+

--- a/custom_components/keba/sensor.py
+++ b/custom_components/keba/sensor.py
@@ -21,13 +21,34 @@ from homeassistant.const import (
     UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfPower,
+    UnitOfTemperature,
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, KEBA_CONNECTION
+from .const import (
+    CHARGING_STATIONS,
+    CONF_DEVICE_TYPE,
+    DEVICE_TYPE_P40,
+    DEVICE_TYPE_UDP,
+    DOMAIN,
+    KEBA_CONNECTION,
+)
 from .entity import KebaBaseEntity
+
+# Sensors that are only applicable to UDP-based devices (not P40)
+UDP_ONLY_SENSORS = {
+    "Setenergy",  # Energy target - P40 doesn't support setting energy limits
+    "Curr timer",  # Planned current - works differently in P40
+    "Tmo CT",  # Time until planned current - not applicable to P40
+    "Error1",  # UDP-specific error format
+    "Error2",  # UDP-specific error format
+    "Enable sys",  # UDP-specific
+    "Enable user",  # UDP-specific
+    "Sec",  # Uptime - not available in P40 API
+    "X2 phaseSwitch source",  # UDP-specific
+}
 
 SENSOR_TYPES = [
     # default
@@ -251,6 +272,64 @@ SENSOR_TYPES = [
     ),
 ]
 
+# P40-specific sensors
+P40_SENSOR_TYPES = [
+    SensorEntityDescription(
+        key="Curr offered",
+        name="Current Offered",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key="Temperature",
+        name="Temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key="Phases Supported",
+        name="Phases Supported",
+        icon="mdi:sine-wave",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key="Phase Used",
+        name="Phase Used",
+        icon="mdi:sine-wave",
+    ),
+    SensorEntityDescription(
+        key="Raw State",
+        name="Raw State",
+        icon="mdi:state-machine",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key="Error Code",
+        name="Error Code",
+        icon="mdi:alert-circle",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key="Model",
+        name="Model",
+        icon="mdi:information",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key="Firmware Version",
+        name="Firmware Version",
+        icon="mdi:chip",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+]
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -258,12 +337,23 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Keba charging station sensors from config entry."""
-    keba: KebaKeContact = hass.data[DOMAIN][KEBA_CONNECTION]
-    entities: list[KebaSensor] = []
+    device_type = config_entry.data.get(CONF_DEVICE_TYPE, DEVICE_TYPE_UDP)
 
-    charging_station = keba.get_charging_station(config_entry.data[CONF_HOST])
+    if device_type == DEVICE_TYPE_P40:
+        charging_station = hass.data[DOMAIN][CHARGING_STATIONS][config_entry.entry_id]
+        # For P40: use common sensors (excluding UDP-only) plus P40-specific sensors
+        sensor_types = [
+            desc for desc in SENSOR_TYPES if desc.key not in UDP_ONLY_SENSORS
+        ] + P40_SENSOR_TYPES
+    else:
+        keba: KebaKeContact = hass.data[DOMAIN][KEBA_CONNECTION]
+        charging_station = keba.get_charging_station(config_entry.data[CONF_HOST])
+        # For UDP: use all common sensors
+        sensor_types = SENSOR_TYPES
+
+    entities: list[KebaSensor] = []
     entities.extend(
-        [KebaSensor(charging_station, description) for description in SENSOR_TYPES]
+        [KebaSensor(charging_station, description) for description in sensor_types]
     )
     async_add_entities(entities, True)
 

--- a/custom_components/keba/translations/de.json
+++ b/custom_components/keba/translations/de.json
@@ -4,7 +4,8 @@
       "user": {
         "data": {
           "description": "Verbinde dich mit deiner Ladestation, wenn die IP-Adresse nicht eingestellt ist, wird die automatische Erkennung verwendet",
-          "host": "Host (IP Adresse)"
+          "host": "Host (IP Adresse)",
+          "password": "Passwort (für P40/P40 Pro)"
         }
       }
     },

--- a/custom_components/keba/translations/en.json
+++ b/custom_components/keba/translations/en.json
@@ -11,7 +11,8 @@
     "step": {
       "user": {
         "data": {
-          "host": "Host (IP Address)"
+          "host": "Host (IP Address)",
+          "password": "Password (for P40/P40 Pro)"
         }
       }
     }


### PR DESCRIPTION
This PR adds support for the new KEBA P40 and P40 Pro charging stations, which use a REST API v2 instead of the UDP protocol used by older models. This probably is not a perfect implementation yet, but it is a good starting point and it works solid in my use case.

**New Features**

- P40 REST API Client (p40_api.py): Full implementation of the P40 REST API v2 with JWT authentication, automatic token refresh on 401 errors, and SSL support for HTTPS on port 8443
- P40 Charging Station Wrapper (p40_charging_station.py): Maps P40 API data to the existing entity format for seamless integration
- Automatic Device Detection: Config flow detects device type (UDP vs P40) during setup and prompts for password when P40 is detected

**Supported Entities for P40**

- Sensors: Status, Charging Power, Session Energy, Total Energy, Set Current, Current Offered, Temperature, Voltage/Current per phase, Session ID/Start/End times, and more
- Binary Sensors: Charging state, Plug status (EV and station side), Online status, Session Active
- Lock: Start/Stop charging (replaces Enable/Disable buttons for P40)
- Number: Charging current control via Load Management API
- Button: Request data refresh, Unlock socket (socket versions only)

**Key Implementation Details**

- Load management API integration for reading/setting max_available_current
- Hides UDP-specific entities that don't apply to P40 devices

**Backward Compatibility**
Existing UDP-based KEBA charging stations continue to work unchanged. The integration automatically detects the device type during configuration.