### PR TITLE
fix: Remove assignment of config_entry in KebaOptionsFlow.__init__

### DIFF
--- a/custom_components/keba/config_flow.py
+++ b/custom_components/keba/config_flow.py
@@ -154,7 +154,6 @@ class KebaOptionsFlow(OptionsFlow):
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize keba charging station option flow."""
-        self.config_entry = config_entry
         self.options = dict(config_entry.options)
 
     async def async_step_init(

--- a/custom_components/keba/const.py
+++ b/custom_components/keba/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Abfallplus integration."""
+"""Constants for the keba integration."""
 
 DOMAIN = "keba"
 CHARGING_STATIONS = "wallboxes"


### PR DESCRIPTION
`config_entry` is a read only calculated property implemented in the base class `OptionsFlow` and will already contain the `ConfigEntry`. So no assignet is needed.

Assigning to it will result in an error:
> AttributeError: property 'config_entry' of 'KebaOptionsFlow' object has no setter