### PR TITLE
Refactor KEBA notify service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .vscode
+.DS_Store

--- a/custom_components/keba/__init__.py
+++ b/custom_components/keba/__init__.py
@@ -7,11 +7,18 @@ from keba_kecontact.charging_station import ChargingStation, KebaService
 from keba_kecontact.connection import KebaKeContact, SetupError
 import voluptuous as vol
 
+from homeassistant.components import notify as hass_notify
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_DEVICE_ID, CONF_HOST, Platform
+from homeassistant.const import (
+    ATTR_CONFIG_ENTRY_ID,
+    CONF_DEVICE_ID,
+    CONF_HOST,
+    CONF_NAME,
+    Platform,
+)
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
@@ -31,7 +38,6 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.LOCK,
-    Platform.NOTIFY,
     Platform.NUMBER,
     Platform.SENSOR,
 ]
@@ -153,6 +159,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Set up all platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    if KebaService.DISPLAY in charging_station.device_info.available_services():
+        hass.async_create_task(
+            discovery.async_load_platform(
+                hass,
+                Platform.NOTIFY,
+                DOMAIN,
+                {
+                    CONF_NAME: entry.title,
+                    ATTR_CONFIG_ENTRY_ID: entry.entry_id,
+                },
+                hass.data[DOMAIN][DATA_HASS_CONFIG],
+            )
+        )
+
     return True
 
 
@@ -162,23 +182,25 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    # Remove notify
     charging_station = keba.get_charging_station(entry.data[CONF_HOST])
-    # if KebaService.DISPLAY in charging_station.device_info.available_services():
-    #     hass.services.async_remove(
-    #         Platform.NOTIFY, f"{DOMAIN}_{slugify(charging_station.device_info.model)}"
-    #     )
+    if charging_station is None:
+        return unload_ok
 
     # Only remove services if it is the last charging station
-    if len(hass.data[DOMAIN][CHARGING_STATIONS]) == 1:
-        _LOGGER.debug("Removing last charging station, cleanup services")
-
-        for service in charging_station.device_info.available_services():
-            hass.services.async_remove(DOMAIN, service.value)
+    last_charging_station = len(hass.data[DOMAIN][CHARGING_STATIONS]) == 1
 
     if unload_ok:
         keba.remove_charging_station(entry.data[CONF_HOST])
         hass.data[DOMAIN][CHARGING_STATIONS].pop(entry.entry_id)
+
+        if KebaService.DISPLAY in charging_station.device_info.available_services():
+            await hass_notify.async_reload(hass, DOMAIN)
+
+    if last_charging_station:
+        _LOGGER.debug("Removing last charging station, cleanup services")
+
+        for service in charging_station.device_info.available_services():
+            hass.services.async_remove(DOMAIN, service.value)
 
     return unload_ok
 

--- a/custom_components/keba/notify.py
+++ b/custom_components/keba/notify.py
@@ -1,57 +1,58 @@
 """Support for Keba notifications."""
 
+from __future__ import annotations
+
+from typing import Any
+
 from keba_kecontact.charging_station import ChargingStation
 
-from homeassistant.components.notify import NotifyEntity, NotifyEntityDescription
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
+from homeassistant.components.notify import ATTR_DATA, BaseNotificationService
+from homeassistant.const import ATTR_CONFIG_ENTRY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DOMAIN, KEBA_CONNECTION
-from .entity import KebaBaseEntity
+from .const import CHARGING_STATIONS, DOMAIN
 
 
-async def async_setup_entry(
+async def async_get_service(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up the keba entity platform."""
+    config: ConfigType,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> BaseNotificationService | None:
+    """Return the notify service."""
+    if discovery_info is None:
+        return None
 
-    keba = hass.data[DOMAIN][KEBA_CONNECTION]
-    charging_station = keba.get_charging_station(config_entry.data[CONF_HOST])
-    async_add_entities(
-        [
-            KebaNotifyEntity(
-                charging_station,
-                NotifyEntityDescription(
-                    key="display",
-                    name="Display",
-                    device_class="display",
-                ),
-            )
-        ]
+    charging_station = hass.data[DOMAIN][CHARGING_STATIONS].get(
+        discovery_info[ATTR_CONFIG_ENTRY_ID]
     )
+    if charging_station is None:
+        return None
+
+    return KebaNotificationService(charging_station)
 
 
-class KebaNotifyEntity(KebaBaseEntity, NotifyEntity):
-    """Implement keba notification platform."""
+class KebaNotificationService(BaseNotificationService):
+    """Notification service for KEBA charging stations."""
 
-    def __init__(
-        self,
-        charging_station: ChargingStation,
-        description: NotifyEntityDescription,
-    ) -> None:
-        """Initialize the KEBA Sensor."""
-        super().__init__(charging_station, description)
+    def __init__(self, charging_station: ChargingStation) -> None:
+        """Initialize the service."""
+        self._charging_station = charging_station
 
-    async def async_send_message(self, message: str, title: str | None = None) -> None:
+    async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send the message."""
+        text = message.replace(" ", "$")
+
+        data = kwargs.get(ATTR_DATA) or {}
+        min_time = float(data.get("min_time", 2))
+        max_time = float(data.get("max_time", 10))
+
         try:
-            await self._charging_station.display(message)
+            await self._charging_station.display(text, min_time, max_time)
         except NotImplementedError as ex:
             raise ServiceValidationError(
                 "Display is not available on selected charging station"
             ) from ex
+        except ValueError as ex:
+            raise ServiceValidationError(str(ex)) from ex


### PR DESCRIPTION
Unfortunately, the `notify.send_message` service does not work properly with the KEBA P30 Wallbox because the `min_time` and `max_time` values should be included in the data. Otherwise, the service may lose some messages, especially if a group of messages is configured to sent repeatedly.

Therefore, I have added the service from the core version of the KEBA integration and removed the send_message version.